### PR TITLE
Make profile caching work for all users (Current and Visitor) #10

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sdp/musiconnect/VisitorProfileTest.java
+++ b/app/src/androidTest/java/ch/epfl/sdp/musiconnect/VisitorProfileTest.java
@@ -95,7 +95,9 @@ public class VisitorProfileTest {
         onView(withId(R.id.visitorProfileLastname)).check(matches(withText(m.getLastName())));
         onView(withId(R.id.visitorProfileUsername)).check(matches(withText(m.getUserName())));
         onView(withId(R.id.visitorProfileEmail)).check(matches(withText(m.getEmailAddress())));
-        onView(withId(R.id.visitorProfileBirthday)).check(matches(withText(m.getBirthday().toString())));
+        MyDate date = m.getBirthday();
+        String s = date.getDate() + "/" + date.getMonth() + "/" + date.getYear();
+        onView(withId(R.id.visitorProfileBirthday)).check(matches(withText(s)));
 
         visitorActivityTestRule.finishActivity();
     }

--- a/app/src/main/java/ch/epfl/sdp/musiconnect/MyProfilePage.java
+++ b/app/src/main/java/ch/epfl/sdp/musiconnect/MyProfilePage.java
@@ -8,30 +8,14 @@ import android.os.Bundle;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
-import android.widget.Toast;
 
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
-import java.util.List;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-
 import ch.epfl.sdp.R;
-import ch.epfl.sdp.musiconnect.database.DbAdapter;
-import ch.epfl.sdp.musiconnect.database.DbCallback;
 import ch.epfl.sdp.musiconnect.database.DbGenerator;
-import ch.epfl.sdp.musiconnect.database.DbUserType;
-import ch.epfl.sdp.musiconnect.roomdatabase.AppDatabase;
-import ch.epfl.sdp.musiconnect.roomdatabase.MusicianDao;
-
-import static ch.epfl.sdp.musiconnect.ConnectionCheck.checkConnection;
 
 public class MyProfilePage extends ProfilePage implements View.OnClickListener {
     private static int LAUNCH_PROFILE_MODIF_INTENT = 102;
-    private DbAdapter dbAdapter;
-
-    private Musician currentCachedUser;
 
     @SuppressLint("ClickableViewAccessibility")
     @Override
@@ -49,13 +33,14 @@ public class MyProfilePage extends ProfilePage implements View.OnClickListener {
         usernameView = findViewById(R.id.myUsername);
         emailView = findViewById(R.id.myMail);
         birthdayView = findViewById(R.id.myBirthday);
+        userEmail = CurrentUser.getInstance(this).email;
 
         Button editProfile = findViewById(R.id.btnEditProfile);
         editProfile.setOnClickListener(v -> {
-                Intent profileModificationIntent = new Intent(this, ProfileModification.class);
-                sendInformation(profileModificationIntent);
-                // Permits sending information from child to parent activity
-                startActivityForResult(profileModificationIntent, LAUNCH_PROFILE_MODIF_INTENT);
+            Intent profileModificationIntent = new Intent(this, ProfileModification.class);
+            sendInformation(profileModificationIntent);
+            // Permits sending information from child to parent activity
+            startActivityForResult(profileModificationIntent, LAUNCH_PROFILE_MODIF_INTENT);
 
         });
 
@@ -74,60 +59,19 @@ public class MyProfilePage extends ProfilePage implements View.OnClickListener {
         return super.onOptionsItemSelected(item);
     }
 
-    private void loadProfileContent() {
-        Executor mExecutor = Executors.newSingleThreadExecutor();
-        AppDatabase localDb = AppDatabase.getInstance(this);
-        MusicianDao mdao = localDb.musicianDao();
-        userEmail = CurrentUser.getInstance(this).email;
-      
-        //fetches the current user's profile
-        mExecutor.execute(() -> {
-            List<Musician> result = mdao.loadAllByIds(new String[]{userEmail});
-            currentCachedUser = result.isEmpty() ? null : result.get(0);
-        });
+    @Override
+    protected void loadUserProfile(User user) {
+        Musician m = (Musician) user;
 
-        try { // wait for async thread to fetch cached profile
-            TimeUnit.MILLISECONDS.sleep(500);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-        // gets profile info from database
-        if (checkConnection(MyProfilePage.this)) {
-            dbAdapter.read(DbUserType.Musician, CurrentUser.getInstance(this).email, new DbCallback() {
-                @Override
-                public void readCallback(User user) {
-                    Musician m = (Musician) user;
-                    firstNameView.setText(m.getFirstName());
-                    lastNameView.setText(m.getLastName());
-                    usernameView.setText(m.getUserName());
-                    emailView.setText(m.getEmailAddress());
-                    MyDate date = m.getBirthday();
-                    String s = date.getDate() + "/" + date.getMonth() + "/" + date.getYear();
-                    birthdayView.setText(s);
-                    // if user profile isn't cached,cache it
-                    if (currentCachedUser == null || !ProfileModification.changeStaged) {
-                        mExecutor.execute(() -> {
-                            mdao.insertAll(m);
-                        });
-                    }
-                }
-            });
+        firstNameView.setText(m.getFirstName());
+        lastNameView.setText(m.getLastName());
+        usernameView.setText(m.getUserName());
 
-        } else {
-            if (currentCachedUser == null) {
-                Toast.makeText(this, "Unable to fetch profile information; please connect to internet", Toast.LENGTH_LONG).show();
-            } else { // set profile info based on cache
-                firstNameView.setText(currentCachedUser.getFirstName());
-                lastNameView.setText(currentCachedUser.getLastName());
-                usernameView.setText(currentCachedUser.getUserName());
-                emailView.setText(currentCachedUser.getEmailAddress());
-                MyDate date = currentCachedUser.getBirthday();
+        MyDate date = m.getBirthday();
+        String s = date.getDate() + "/" + date.getMonth() + "/" + date.getYear();
+        birthdayView.setText(s);
 
-                String s = date.getDate() + "/" + date.getMonth() + "/" + date.getYear();
-                birthdayView.setText(s);
-            }
-        }
-
+        emailView.setText(m.getEmailAddress());
     }
 
     @Override

--- a/app/src/main/java/ch/epfl/sdp/musiconnect/ProfileModification.java
+++ b/app/src/main/java/ch/epfl/sdp/musiconnect/ProfileModification.java
@@ -171,7 +171,7 @@ public class ProfileModification extends ProfilePage implements View.OnClickList
             }
         }
         if (result.isEmpty()) {
-            Toast.makeText(ProfileModification.this, "Error: couldn't update profile", Toast.LENGTH_LONG);
+            Toast.makeText(ProfileModification.this, "Error: couldn't update profile", Toast.LENGTH_LONG).show();
             finish();
             return;
         }
@@ -189,7 +189,7 @@ public class ProfileModification extends ProfilePage implements View.OnClickList
             cUserBirthday = dateToMyDate(d);
 
         } catch (ParseException e) {
-            Toast.makeText(ProfileModification.this, "Error: couldn't update profile", Toast.LENGTH_LONG);
+            Toast.makeText(ProfileModification.this, "Error: couldn't update profile", Toast.LENGTH_LONG).show();
             finish();
             return;
         }

--- a/app/src/main/java/ch/epfl/sdp/musiconnect/ProfileModification.java
+++ b/app/src/main/java/ch/epfl/sdp/musiconnect/ProfileModification.java
@@ -50,7 +50,6 @@ public class ProfileModification extends ProfilePage implements View.OnClickList
     private List<Musician> result; //used to fetch from room database
     public static boolean changeStaged = false;    //indicates if there are changes not commited to online database yet
 
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -271,5 +270,10 @@ public class ProfileModification extends ProfilePage implements View.OnClickList
             mVideoView.start();
             mVideoView.setOnCompletionListener(mediaPlayer -> mVideoView.start());
         }
+    }
+
+    @Override
+    protected void loadUserProfile(User user) {
+
     }
 }

--- a/app/src/main/java/ch/epfl/sdp/musiconnect/ProfilePage.java
+++ b/app/src/main/java/ch/epfl/sdp/musiconnect/ProfilePage.java
@@ -7,13 +7,22 @@ import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.VideoView;
 
-import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import ch.epfl.sdp.R;
 import ch.epfl.sdp.musiconnect.cloud.CloudCallback;
 import ch.epfl.sdp.musiconnect.cloud.CloudStorage;
 import ch.epfl.sdp.musiconnect.cloud.CloudStorageGenerator;
-import ch.epfl.sdp.musiconnect.cloud.FirebaseCloudStorage;
+import ch.epfl.sdp.musiconnect.database.DbAdapter;
+import ch.epfl.sdp.musiconnect.database.DbCallback;
+import ch.epfl.sdp.musiconnect.database.DbUserType;
+import ch.epfl.sdp.musiconnect.roomdatabase.AppDatabase;
+import ch.epfl.sdp.musiconnect.roomdatabase.MusicianDao;
+
+import static ch.epfl.sdp.musiconnect.ConnectionCheck.checkConnection;
 
 public abstract class ProfilePage extends Page {
     protected TextView titleView, firstNameView, lastNameView, usernameView, emailView, birthdayView;
@@ -21,6 +30,64 @@ public abstract class ProfilePage extends Page {
     protected VideoView mVideoView;
     protected ImageView imgVw;
     protected String userEmail;
+    protected DbAdapter dbAdapter;
+    protected Musician currentCachedUser;
+
+    protected void loadProfileContent() {
+        if (userEmail == null || userEmail.isEmpty()) {
+            loadNullProfile();
+            return;
+        }
+
+        Executor mExecutor = Executors.newSingleThreadExecutor();
+        AppDatabase localDb = AppDatabase.getInstance(this);
+        MusicianDao mdao = localDb.musicianDao();
+
+        //fetches the current user's profile
+        mExecutor.execute(() -> {
+            List<Musician> result = mdao.loadAllByIds(new String[]{userEmail});
+            currentCachedUser = result.isEmpty() ? null : result.get(0);
+        });
+
+        try { // wait for async thread to fetch cached profile
+            TimeUnit.MILLISECONDS.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        // gets profile info from database
+        if (checkConnection(ProfilePage.this)) {
+            dbAdapter.read(DbUserType.Musician, userEmail, new DbCallback() {
+                @Override
+                public void readCallback(User user) {
+                    loadUserProfile(user);
+                    // if user profile isn't cached,cache it
+                    if (currentCachedUser == null || !ProfileModification.changeStaged) {
+                        mExecutor.execute(() -> {
+                            mdao.insertAll((Musician) user);
+                        });
+                    }
+                }
+
+                @Override
+                public void readFailCallback() {
+                    loadNullProfile();
+                }
+            });
+
+        } else {
+            if (currentCachedUser == null) {
+                Toast.makeText(this, "Unable to fetch profile information; please connect to internet", Toast.LENGTH_LONG).show();
+            } else { // set profile info based on cache
+                loadUserProfile(currentCachedUser);
+            }
+        }
+    }
+
+    protected abstract void loadUserProfile(User user);
+
+    private void loadNullProfile() {
+        setContentView(R.layout.activity_visitor_profile_page_null);
+    }
 
     protected void showVideo() {
         if (videoUri != null) {

--- a/app/src/main/java/ch/epfl/sdp/musiconnect/cloud/FirebaseCloudStorage.java
+++ b/app/src/main/java/ch/epfl/sdp/musiconnect/cloud/FirebaseCloudStorage.java
@@ -70,6 +70,10 @@ public class FirebaseCloudStorage implements CloudStorage {
     }
 
     public void download(FileType fileType, String username, CloudCallback cloudCallback) {
+        if(username == null || username.isEmpty()) {
+            cloudCallback.onFailure();
+            return;
+        }
 
         if (ConnectionCheck.checkConnection(context)) {
             String cloudPath = username + "/" + fileType;
@@ -85,13 +89,6 @@ public class FirebaseCloudStorage implements CloudStorage {
 
                         if (!cacheDirectory.exists())
                             cacheDirectory.mkdir();
-
-//                    Log.d(TAG, directory.exists() + "");
-//
-//                    String[] paths = directory.list();
-//
-//                    for (String p : paths)
-//                        Log.d(TAG, p);
 
                         File localFile = new File(cacheDirectory, localFileName);
 


### PR DESCRIPTION
Refactored the loadProfileContent and moved it to ProfilePage, and made it use abstract
method loadUserProfile which is implemented differently in each profile page type.
Also added some robustness to FirebaseCloudStorage in case the userEmail is null.